### PR TITLE
fix handle console.Console is undefined issue

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -1,9 +1,10 @@
 'use strict';
 
 const utils = require('./utils');
+const { Console } = require('console');
 
 module.exports = function abslog(logger) {
-    if (logger && logger instanceof console.Console) {
+    if (logger && logger instanceof Console) {
         return Object.create(utils.consoleLogger);
     }
     return utils.validateLogger(logger) ? logger : Object.create(utils.noopLogger);


### PR DESCRIPTION
It seems that under some circumstances, console.Console can be
'undefined'. This fixes this by always importing and relying on the Console class
directly.