### PR TITLE
fix: change console.trace to always be console.log

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,7 +6,7 @@ const consoleLogger = {
     warn: console.warn ? console.warn : console.log,
     info: console.info ? console.info : console.log,
     debug: console.log, // node seems to say it has a .debug(), despite its not public :/
-    trace: console.trace ? console.trace : console.log,
+    trace: console.log, // node has console.trace but it is for printing out stack traces which we don't want
 };
 
 function validateMethod(method) {


### PR DESCRIPTION
It turns out node has a console.trace method but it's not so much a logging method as a method for outputting stack traces so it is probably best if we just use console.log I think.