### PR TITLE
Use Object.is to compare logger with console

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -4,7 +4,7 @@ const NoopLog = require('nooplog');
 const utils = require('./utils');
 
 module.exports = function abslog(logger) {
-    if (logger && logger instanceof global.console.Console) {
+    if (Object.is(logger, console)) {
         return Object.create(utils.consoleLogger);
     }
     return utils.validateLogger(logger) ? logger : new NoopLog();


### PR DESCRIPTION
We can not rely on comparing `global.console.Console` due to some popular frameworks overriding it making `instance` checks fail. Use `Object.is()` instead.