### PR TITLE
fix: adding type information

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "version": "2.4.0",
   "description": "An abstract logger - Enables adding logging to modules without adding a dependency to a full log library.  ",
   "main": "lib/log.js",
+  "types": "types/log.d.ts",
   "files": [
-    "lib"
+    "lib",
+    "types"
   ],
   "scripts": {
     "test": "tap test/*.js",

--- a/types/log.d.ts
+++ b/types/log.d.ts
@@ -1,0 +1,16 @@
+export type LogFunciton = (...args: any) => void;
+
+/**
+ * An abstract logger which enables adding logging to modules without adding a dependency to a full log library
+ */
+export type AbstractLogger = {
+    trace: LogFunciton,
+    debug: LogFunciton,
+    info: LogFunciton,
+    warn: LogFunciton,
+    error: LogFunciton,
+    fatal: LogFunciton
+}
+
+declare function abstractLogger(logger: any): AbstractLogger;
+export default abstractLogger;


### PR DESCRIPTION
This PR adds some basic type information to the logging repo. A different option would be to add this information to the `@types` repository if you don't want the types here 🤷 